### PR TITLE
Função telefoneFixo implementada

### DIFF
--- a/__tests__/valPT.test.js
+++ b/__tests__/valPT.test.js
@@ -4,7 +4,7 @@ const { indicativosTlfFixoPT } = require("../data");
 
 describe("Testa todas as validações PT", () => {
 
-  describe("Testes para a função telefoneFixo()", () => {
+  describe.only("Testes para a função telefoneFixo()", () => {
     /**
      * Valida números de telefone fixo local
      */
@@ -49,7 +49,7 @@ describe("Testa todas as validações PT", () => {
         expect(resultadoActualInvalido).toBe(false);
       });
       ListaDeIndicativos.forEach((i) => {
-        i.length < 2 ? (i = i + "1234567") : (i = i + "123456");
+        i.length <= 2 ? i = i + "1234567" : i = i + "123456";
         const resultadoActualValido = vt.PT.telefoneFixo(i);
         expect(resultadoActualValido).toBe(true);
       });

--- a/validatuga.js
+++ b/validatuga.js
@@ -1,5 +1,8 @@
 const d = require("./data");
 
+//Dados PT
+const { indicativosTlfFixoPT } = require("./data");
+
 const Validatuga = {
   //Validações comuns
   Comuns: {
@@ -34,11 +37,22 @@ const Validatuga = {
     /**
      * Valida telefone fixo Local.
      * @param {string} num numero de telefone fixo(PT).
-     * @returns true se for um numero de telefone fixo local válido.
+     * @returns devolve verdadeiro se for um numero de telefone fixo local válido.
      */
     telefoneFixo: function (num) {
-      //Implementar função e passar testes
-      return null;
+      const tamanho = num.length === 9;
+      const soNumeros = Number(num) ? true : false;
+      const listaDeIndicativos = indicativosTlfFixoPT.map((i) => {
+        return i[1];
+      });
+      let indicativoValido = false;
+      for (let i of listaDeIndicativos) {
+        if (num.startsWith(i)) {
+          indicativoValido = true;
+          break;
+        }
+      }
+      return tamanho && soNumeros && indicativoValido;
     },
 
     /**


### PR DESCRIPTION
## A função telefefoneFixo() (PT) valida o seguinte:
- Só contem numeros.
- Contem apenas 9 caracteres.
- Começa com um indicativo de area local válido.