### PR TITLE
Adicionados testes e função nifVal(); função soNumeros() refatorada.

### DIFF
--- a/__tests__/valPT.test.js
+++ b/__tests__/valPT.test.js
@@ -3,7 +3,6 @@ const vt = require("../validatuga.js");
 const { indicativosTlfFixoPT } = require("../data");
 
 describe("Testa todas as validações PT", () => {
-
   describe("Testes para a função telefoneFixoVal()", () => {
     /**
      * Valida números de telefone fixo local
@@ -49,7 +48,7 @@ describe("Testa todas as validações PT", () => {
         expect(resultadoActualInvalido).toBe(false);
       });
       ListaDeIndicativos.forEach((i) => {
-        i.length <= 2 ? i = i + "1234567" : i = i + "123456";
+        i.length <= 2 ? (i = i + "1234567") : (i = i + "123456");
         const resultadoActualValido = vt.PT.telefoneFixoVal(i);
         expect(resultadoActualValido).toBe(true);
       });
@@ -132,6 +131,54 @@ describe("Testa todas as validações PT", () => {
       });
       //assertions
       expect(resultadoActualValido).toBe(true);
+    });
+  });
+
+  describe("Testes para a função nifVal()", () => {
+    test("Contém apenas 9 caracteres.", () => {
+      //arrange
+      const nifValido = "999999990";
+      const nifsInvalidos = ["999", "9999999999"];
+      //act
+      const resultadoActualValido = vt.PT.nifVal(nifValido);
+      nifsInvalidos.forEach((nif) => {
+        const resultadoActualInvalido = vt.PT.nifVal(nif);
+        //assertions
+        expect(resultadoActualInvalido).toBe(false);
+      });
+      //assertions
+      expect(resultadoActualValido).toBe(true);
+    });
+
+    test("Só contem números", () => {
+      //arrange
+      const nifValido = "999999990";
+      const nifsInvalidos = ["999sdfa", "99999 9990", "safsdafds", "99999999 "];
+      //act
+      const resultadoActualValido = vt.PT.nifVal(nifValido);
+      nifsInvalidos.forEach((nif) => {
+        const resultadoActualInvalido = vt.PT.nifVal(nif);
+        console.log(resultadoActualInvalido + nif);
+        //assertions
+        expect(resultadoActualInvalido).toBe(false);
+      });
+      //assertions
+      expect(resultadoActualValido).toBe(true);
+    });
+
+    test("Valida com base no número de controlo.", () => {
+      //arrange
+      const nifsValidos = ["999999990", "501442600", "505305500"];
+      const nifInvalido = "999999999";
+      //act
+      const resultadoActualInvalido = vt.PT.nifVal(nifInvalido);
+      nifsValidos.forEach((nif) => {
+        const resultadoActualValido = vt.PT.nifVal(nif);
+        //assertions
+        expect(resultadoActualValido).toBe(true);
+      });
+      //assertions
+      expect(resultadoActualInvalido).toBe(false);
     });
   });
 });

--- a/data.js
+++ b/data.js
@@ -86,6 +86,12 @@ const indicativosTelemovel = [
   ["Vodafone", "921"],
 ];
 
+// nif data
+const validationSets = {
+  one: ["1", "2", "3", "5", "6", "8"],
+  two: ["45", "70", "71", "72", "74", "75", "77", "79", "90", "91", "98", "99"],
+};
+
 //Brazil
 
 //Angola
@@ -104,4 +110,5 @@ module.exports = {
   indicativosTlfFixoPT,
   planoNumeracaoPT,
   indicativosTelemovel,
+  validationSets,
 };

--- a/util.js
+++ b/util.js
@@ -1,10 +1,14 @@
-// Funções utilitárias de apoio a validatuga.js
+// Funções utilitárias de apoio a validatuga.js~
 
-const soNumeros = (num) => {
-  return Number(num) ? true : false;
-}
-
+/**
+ * Valida se uma string só contem numeros.
+ * @param {string} str
+ * @returns verdadeiro se só contém números.
+ */
+const soNumeros = (str) => {
+  return /^\d+$/.test(str);
+};
 
 module.exports = {
-    soNumeros
-  };
+  soNumeros,
+};

--- a/validatuga.js
+++ b/validatuga.js
@@ -3,7 +3,11 @@
 const d = require("./data");
 
 //Dados PT
-const { indicativosTlfFixoPT, indicativosTelemovel } = require("./data");
+const {
+  indicativosTlfFixoPT,
+  indicativosTelemovel,
+  validationSets,
+} = require("./data");
 //Utilitários
 const { soNumeros } = require("./util");
 
@@ -33,7 +37,7 @@ const Validatuga = {
 
   /**
    * Validações de dados de Portugal como numeros
-   * de telefone, CC, telemovel, NIF etc...
+   * de telefone, CC, telemovel, num etc...
    */
   PT: {
     /**
@@ -108,7 +112,7 @@ const Validatuga = {
     /**
      * Valida o número de cartão de cidadão. (PT)
      * @param {string} num Recebe um número de CC.
-     * @returns verdadeiro se for um número válido. 
+     * @returns verdadeiro se for um número válido.
      */
     ccidadaoVal: function (num) {
       return null;
@@ -116,16 +120,39 @@ const Validatuga = {
 
     /**
      * Valida um número de identificação fiscal. (PT)
-     * @param {string} num Recebe um número nif. 
+     * @param {string} num Recebe um número nif.
      * @returns verdadeiro se for um número válido.
      */
     nifVal: function (num) {
-      return null;
+      if (soNumeros(num) === false) return false;
+      if (num.length !== 9) return false;
+
+      if (
+        !validationSets.one.includes(num.substr(0, 1)) &&
+        !validationSets.two.includes(num.substr(0, 2))
+      ) {
+        return false;
+      }
+
+      const total =
+        num[0] * 9 +
+        num[1] * 8 +
+        num[2] * 7 +
+        num[3] * 6 +
+        num[4] * 5 +
+        num[5] * 4 +
+        num[6] * 3 +
+        num[7] * 2;
+      const modulo11 = Number(total) % 11;
+
+      const checkDigit = modulo11 < 2 ? 0 : 11 - modulo11;
+
+      return checkDigit === Number(num[8]);
     },
 
     /**
      * Valida um número do sistema nacional de saúde. (PT)
-     * @param {string} num Recebe um número niss. 
+     * @param {string} num Recebe um número niss.
      * @returns verdadeiro se for um número válido.
      */
     nissVal: function (num) {
@@ -134,26 +161,25 @@ const Validatuga = {
 
     /**
      * Valida um número de carta de condução. (PT)
-     * @param {string} num Recebe um número carta de condução. 
+     * @param {string} num Recebe um número carta de condução.
      * @returns verdadeiro se for um número válido.
      */
     cConducaoVal: function (num) {
       return null;
     },
 
-    //Adicionar mais validações abaixo. 
-
+    //Adicionar mais validações abaixo.
   },
 
   /**
    * Validações de dados sociais do Brazil como numeros
-   * de telefone, CC, telemovel, NIF etc...
+   * de telefone, CC, telemovel, num etc...
    */
   BR: {},
 
   /**
    * Validações de dados de Angola como numeros
-   * de telefone, CC, telemovel, NIF etc...
+   * de telefone, CC, telemovel, num etc...
    */
   ANG: {},
 };


### PR DESCRIPTION
- Adicionados testes e função nifVal();
  - testes validam se só contém números. 
  - contem 9 caracteres
  - valida com base no número de controlo.

- função soNumeros() em util.js agora invalida números com espaço no fim.