### PR TITLE
Criados testes e função telemovelOp()

### DIFF
--- a/__tests__/valPT.test.js
+++ b/__tests__/valPT.test.js
@@ -158,7 +158,6 @@ describe("Testa todas as validações PT", () => {
       const resultadoActualValido = vt.PT.nifVal(nifValido);
       nifsInvalidos.forEach((nif) => {
         const resultadoActualInvalido = vt.PT.nifVal(nif);
-        console.log(resultadoActualInvalido + nif);
         //assertions
         expect(resultadoActualInvalido).toBe(false);
       });
@@ -179,6 +178,51 @@ describe("Testa todas as validações PT", () => {
       });
       //assertions
       expect(resultadoActualInvalido).toBe(false);
+    });
+  });
+
+  describe("Testes para a função telemovelOp", () => {
+    test("Devolve operadoras correspondentes.", () => {
+      //arrange
+      const numsValidosMeo = [
+        "961231231",
+        "924012312",
+        "924412312",
+        "925123123",
+        "927123123",
+      ];
+      const numValidoNos = "931231234";
+      const numsValidosVodafone = ["911234123", "921123123"];
+      const resultadoEsperadoMeo = "MEO";
+      const resultadoEsperadoNos = "NOS";
+      const resultadoEsperadoVodafone = "Vodafone";
+
+      //act
+      numsValidosMeo.forEach((num) => {
+        const resultadoActual = vt.PT.telemovelOp(num);
+        //assertions
+        expect(resultadoActual).toBe(resultadoEsperadoMeo);
+      });
+
+      numsValidosVodafone.forEach((num) => {
+        const resultadoActual = vt.PT.telemovelOp(num);
+        //assertions
+        expect(resultadoActual).toBe(resultadoEsperadoVodafone);
+      });
+
+      const resultadoActual = vt.PT.telemovelOp(numValidoNos);
+      //assertions
+      expect(resultadoActual).toBe(resultadoEsperadoNos);
+    });
+
+    test('Devolve falso quando recebe um número inválido"', () => {
+      //arrange
+      const numInvalido = "123123123";
+      const resultadoEsperado = false;
+      //act
+      const resultadoActual = vt.PT.telemovelOp(numInvalido);
+      //assertions
+      expect(resultadoActual).toBe(false);
     });
   });
 });

--- a/util.js
+++ b/util.js
@@ -1,4 +1,4 @@
-// Funções utilitárias de apoio a validatuga.js~
+// Funções utilitárias de apoio a validatuga.js
 
 /**
  * Valida se uma string só contem numeros.
@@ -9,6 +9,22 @@ const soNumeros = (str) => {
   return /^\d+$/.test(str);
 };
 
+/**
+ * Cria um sequência de números aleatório com o tamanho fornecido.
+ * @param {string} indicativo Números iniciais. string vazia p/defeito.
+ * @param {number} tamanho Tamanho do número. 9 é o valor p/defeito.
+ * @returns string
+ */
+const criaSquencia = (indicativo = "", tamanho = 9) => {
+  let num = "";
+  num += indicativo;
+  while (num.length < tamanho) {
+    num += Math.floor(Math.random() * 10).toString();
+  }
+  return num;
+};
+
 module.exports = {
   soNumeros,
+  criaSquencia,
 };

--- a/validatuga.js
+++ b/validatuga.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const d = require("./data");
-
 //Dados PT
 const {
   indicativosTlfFixoPT,
@@ -87,7 +85,14 @@ const Validatuga = {
      * @returns nome da operadora (ex. 'meo', 'nos', 'vodafone').
      */
     telemovelOp: function (num) {
-      return null;
+      const invalido = false;
+      if (this.telemovelVal(num)) {
+        for (const arr of indicativosTelemovel) {
+          if (num.startsWith(arr[1])) return arr[0];
+        }
+        return invalido;
+      } 
+      return invalido;
     },
 
     /**


### PR DESCRIPTION
Foram criados testes e função telemovelOp() Closes #17
- Dado um número de telemóvel válido a função devolve o nome da operadora.
- Caso o número seja inválido a função devolve falso.
- Testes cobrem todos os números válidos e caso de número inválido.

 